### PR TITLE
Use Typstry.jl to compile documents

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,17 @@ version = "0.1.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Typstry = "f0ed7684-a786-439e-b1e3-3b82803b501e"
 
 [compat]
-julia = "1.9"
 DataFrames = "1.6"
+Typst_jll = "0.8 - 0.11"
+Typstry = "0.1"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Typst_jll = "f0ed7684-a786-439e-b1e3-3b82803b501e"
 
 [targets]
 test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Typstry = "f0ed7684-a786-439e-b1e3-3b82803b501e"
 [compat]
 DataFrames = "1.6"
 Typst_jll = "0.8 - 0.11"
-Typstry = "0.1"
+Typstry = "0.2"
 julia = "1.9"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Create labels containing QR-codes and human-readable codes for your experiments!
 
-The package exports one function only, `labelyst()`, which takes a `Julia` DataFrame and some additional parameters as inputs and translates it into a [Typst](https://typst.app/) file which is then, if desired, compiled into a PDF. To work with `Labelyst.jl` you need Typst installed on your computer, learn about installation [here](https://github.com/typst/typst).
+The package exports one function only, `labelyst()`, which takes a `Julia` DataFrame and some additional parameters as inputs and translates it into a [Typst](https://typst.app/) file which is then, if desired, compiled into a PDF.
 
 ## Basic usage
 

--- a/src/df_to_typst.jl
+++ b/src/df_to_typst.jl
@@ -1,4 +1,5 @@
 using DataFrames
+using Typstry: TypstCommand
 
 function make_outfile(output_file)
     if occursin("/", output_file)
@@ -17,7 +18,7 @@ function make_outfile(output_file)
 end
 
 function typtopdf(out_typ)
-    compile_typst = `typst compile $out_typ`
+    compile_typst = TypstCommand(["compile", out_typ])
     run(compile_typst)
 
     remove_typ = `rm $out_typ`


### PR DESCRIPTION
Hi! This PR enables users to use your package without the need to have Typst installed. I also tested the versions of Typst_jll.jl that are compatible with the examples in your README.md and restricted the versions accordingly.

If you are interested in implementing the [Typstry.jl](https://github.com/jakobjpeters/Typstry.jl) interface, you could also create a `Label(::DataFrame)` and specify its Typst format using `show(::IO, ::MIME"text/typst", ::Label)`.